### PR TITLE
잘못된 도메인 정보 바로잡기

### DIFF
--- a/src/main/java/com/board/board/domain/UserAccount.java
+++ b/src/main/java/com/board/board/domain/UserAccount.java
@@ -15,7 +15,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @Table(indexes = {
-    @Index(columnList = "userId"),
+    @Index(columnList = "userId", unique = true),
     @Index(columnList = "email", unique = true),
     @Index(columnList = "createdAt"),
     @Index(columnList = "createdBy")

--- a/src/test/java/com/board/board/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/board/board/repository/JpaRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import com.board.board.config.JpaConfig;
 import com.board.board.domain.Article;
+import com.board.board.domain.UserAccount;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,13 +22,16 @@ class JpaRepositoryTest {
 
   private final ArticleRepository articleRepository;
   private final ArticleCommentRepository articleCommentRepository;
+  private final UserAccountRepository userAccountRepository;
 
   public JpaRepositoryTest(
       @Autowired ArticleRepository articleRepository,
       @Autowired ArticleCommentRepository articleCommentRepository
+      @Autowired UserAccountRepository userAccountRepository
   ) {
     this.articleRepository = articleRepository;
     this.articleCommentRepository = articleCommentRepository;
+    this.userAccountRepository = userAccountRepository;
   }
 
   @DisplayName("select 테스트")
@@ -48,10 +52,11 @@ class JpaRepositoryTest {
   void givenTestData_whenInserting_thenWorksFine() {
     // Given
     long previousCount = articleRepository.count();
+    UserAccount userAccount = userAccountRepository.save(UserAccount.of("godori", "pw", null, null, null));
+    Article article = Article.of(userAccount, "new article", "new content", "#spring");
 
     // When
-    Article savedArticle = articleRepository.save(Article.of("new article", "new content", "#spring"));
-
+    articleRepository.save(article);
     // Then
     assertThat(articleRepository.count()).isEqualTo(previousCount + 1);
   }


### PR DESCRIPTION
회원 계정의 user_id에 UK 적용 완료

This closes #25 