### PR TITLE
[리팩토링] deprecated된 댓글 업데이트 기능 삭제

### DIFF
--- a/src/main/java/com/board/board/service/ArticleCommentService.java
+++ b/src/main/java/com/board/board/service/ArticleCommentService.java
@@ -42,21 +42,6 @@ public class ArticleCommentService {
     }
   }
 
-  /**
-   * @deprecated 댓글 수정 기능은 클라이언트에서 생각할 점이 많아지기 떄문에, 이번 개발에서는 제공하지 않기로 했다.
-   */
-  @Deprecated
-  public void updateArticleComment(ArticleCommentDto dto) {
-    try {
-      ArticleComment articleComment = articleCommentRepository.getReferenceById(dto.id());
-      if (dto.content() != null) {
-        articleComment.setContent(dto.content());
-      }
-    } catch (EntityNotFoundException e) {
-      log.warn("댓글 업데이트 실패. 댓글을 찾을 수 없습니다 - dto: {}", dto);
-    }
-  }
-
   public void deleteArticleComment(Long articleCommentId, String userId) {
     articleCommentRepository.deleteByIdAndUserAccount_UserId(articleCommentId, userId);
   }

--- a/src/test/java/com/board/board/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/board/board/repository/JpaRepositoryTest.java
@@ -61,7 +61,7 @@ class JpaRepositoryTest {
   void givenTestData_whenInserting_thenWorksFine() {
     // Given
     long previousCount = articleRepository.count();
-    UserAccount userAccount = userAccountRepository.save(UserAccount.of("newUno", "pw", null, null, null));
+    UserAccount userAccount = userAccountRepository.save(UserAccount.of("newGodori", "pw", null, null, null));
     Article article = Article.of(userAccount, "new article", "new content");
     article.addHashtags(Set.of(Hashtag.of("spring")));
 

--- a/src/test/java/com/board/board/service/ArticleCommentServiceTest.java
+++ b/src/test/java/com/board/board/service/ArticleCommentServiceTest.java
@@ -85,36 +85,6 @@ class ArticleCommentServiceTest {
     then(articleCommentRepository).shouldHaveNoInteractions();
   }
 
-  @DisplayName("댓글 정보를 입력하면, 댓글을 수정한다.")
-  @Test
-  void givenArticleCommentInfo_whenUpdatingArticleComment_thenUpdatesArticleComment() {
-    // Given
-    String oldContent = "content";
-    String updatedContent = "댓글";
-    ArticleComment articleComment = createArticleComment(oldContent);
-    ArticleCommentDto dto = createArticleCommentDto(updatedContent);
-    given(articleCommentRepository.getReferenceById(dto.id())).willReturn(articleComment);
-    // When
-    sut.updateArticleComment(dto);
-    // Then
-    assertThat(articleComment.getContent())
-        .isNotEqualTo(oldContent)
-        .isEqualTo(updatedContent);
-    then(articleCommentRepository).should().getReferenceById(dto.id());
-  }
-
-  @DisplayName("없는 댓글 정보를 수정하려고 하면, 경고 로그를 찍고 아무 것도 안 한다.")
-  @Test
-  void givenNonexistentArticleComment_whenUpdatingArticleComment_thenLogsWarningAndDoesNothing() {
-    // Given
-    ArticleCommentDto dto = createArticleCommentDto("댓글");
-    given(articleCommentRepository.getReferenceById(dto.id())).willThrow(EntityNotFoundException.class);
-    // When
-    sut.updateArticleComment(dto);
-    // Then
-    then(articleCommentRepository).should().getReferenceById(dto.id());
-  }
-
   @DisplayName("댓글 ID를 입력하면, 댓글을 삭제한다.")
   @Test
   void givenArticleCommentId_whenDeletingArticleComment_thenDeletesArticleComment() {


### PR DESCRIPTION
댓글 업데이트 기능의 삭제 pr
만들어만 두고 프로젝트 기획상 사용하지 않던 기능이었다.

This closes #72 